### PR TITLE
'objID' changed to 'object' for archive and delete

### DIFF
--- a/idoitapi/CMDBCategory.py
+++ b/idoitapi/CMDBCategory.py
@@ -182,7 +182,7 @@ class CMDBCategory(Request):
         self._api.request(
             'cmdb.category.archive',
             {
-                'objID': object_id,
+                'object': object_id,
                 'category': category,
                 'entry': entry_id
             }
@@ -200,7 +200,7 @@ class CMDBCategory(Request):
         self._api.request(
             'cmdb.category.delete',
             {
-                'objID': object_id,
+                'object': object_id,
                 'category': category,
                 'entry': entry_id
             }


### PR DESCRIPTION
After hours of searching I found that the API has changed the keyword `objID` to `object` in the methods **archive** and **delete**. This is the same as described in https://community.i-doit.com/topic/3749/kategorie-erstellen-mit-category-save/2 and officially in https://kb.i-doit.com/en/i-doit-pro-add-ons/api/methods.html.