### PR TITLE
Changed enum type and added .value

### DIFF
--- a/idoitapi/CMDBCondition.py
+++ b/idoitapi/CMDBCondition.py
@@ -1,8 +1,8 @@
-from enum import Enum
+from enum import StrEnum
 from idoitapi.Request import Request
 
 
-class ComparisonOperators(Enum):
+class ComparisonOperators(StrEnum):
     """
     Available comparison operators for conditions
     """
@@ -41,7 +41,7 @@ class ComparisonCondition():
     def to_dict(self) -> dict:
         return {
             "property": self._property,
-            "comparison": self._comparison,
+            "comparison": self._comparison.value,
             "value": self._value
         }
 


### PR DESCRIPTION
Initially the enum object was added to the dict. This patch fixes that problem. Now only the relevant string from the ComparisonOperators Enum is added.